### PR TITLE
changed has_honored_member from faux listview to regular listview

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/awardInOrganization.n3
+++ b/home/src/main/resources/rdf/display/everytime/awardInOrganization.n3
@@ -13,20 +13,4 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix vlocal: <https://experts.colorado.edu/ontology/vivo-fis#> .
 
-@base <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration> .
-
-local:awardInOrganizationContext a :ConfigContext ;
-    :hasConfiguration local:awardInOrganizationConfig ;
-    :configContextFor vlocal:has_honored_member ;
-    :qualifiedByDomain foaf:Organization ;
-    :qualifiedBy foaf:Person .
-
-local:awardInOrganizationConfig a :ObjectPropertyDisplayConfig ;
-    :displayName "award or honor received" ;
-    :listViewConfigFile "listViewConfig-awardInOrganization.xml"^^xsd:string ;
-    :propertyGroup <http://vitro.mannlib.cornell.edu/ns/default#n4400> ;
-    vitro:displayRankAnnot 0;
-    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
-    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
-    vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;
-    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.PersonHasPositionHistoryGenerator"^^xsd:string .
+vlocal:has_honored_member <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#listViewConfigFile> "listViewConfig-awardInOrganization.xml"^^xsd:string .

--- a/home/src/main/resources/rdf/tbox/filegraph/fis.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/fis.owl
@@ -125,8 +125,9 @@
   <owl:ObjectProperty rdf:about="https://experts.colorado.edu/ontology/vivo-fis#has_honored_member">
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
-        <rdfs:label xml:lang="en-us">honored faculty member</rdfs:label>
+        <rdfs:label xml:lang="en-us">award or honor received</rdfs:label>
         <vitro:inPropertyGroupAnnot rdf:resource="http://vitro.mannlib.cornell.edu/ns/default#n4400"/>
+        <vitro:hiddenFromDisplayBelowRoleLevelAnnot rdf:resource="http://vitro.mannlib.cornell.edu/ns/vitro/role#public"/>
   </owl:ObjectProperty>
 
 </rdf:RDF>

--- a/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
@@ -35,13 +35,13 @@
       vitro:ontologyPrefixAnnot "pubs"^^xsd:string .
 
 pubs:ConferenceProceeding a owl:Class ;
-        rdfs:subclassOf bibo:Article ;
+        rdfs:subClassOf bibo:Article ;
         rdfs:label "Conference Proceeding" ;
         vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
         vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGrouppublications> .
 
 pubs:ScholarlyEdition a owl:Class ;
-        rdfs:subclassOf bibo:Article ;
+        rdfs:subClassOf bibo:Article ;
         rdfs:label "Scholarly Edition" ;
         vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
         vitro:inClassGroup <http://vivoweb.org/ontology#vitroClassGrouppublications> .

--- a/home/src/main/resources/rdf/tbox/filegraph/skos-vivo.owl
+++ b/home/src/main/resources/rdf/tbox/filegraph/skos-vivo.owl
@@ -1,0 +1,266 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/arg/skos-vivo.owl#"
+     xml:base="http://purl.obolibrary.org/obo/arg/skos-vivo.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:ns="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<!--
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/arg/skos-vivo.owl">
+        <owl:imports rdf:resource="http://www.w3.org/2008/05/skos-xl"/>
+    </owl:Ontology>
+-->    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"/>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/ontology/bibo/DocumentStatus -->
+
+    <owl:Class rdf:about="http://purl.org/ontology/bibo/DocumentStatus">
+
+<!-- the following axiom causes display issues -->
+<!--        <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/> -->
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The status of a document with respect to its publication.</obo:IAO_0000115>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The status of a document with respect to its publication. The statuses are represented as individuals of this class. Use the &quot;show all individuals of this class&quot; button on the class control panel to see the currently defined statuses.</obo:IAO_0000112>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">submitted; accepted; in-press; published; invited; refereed.</obo:IAO_0000112>
+        <ns:term_status>stable</ns:term_status>
+        <rdfs:comment xml:lang="en">The status of the publication of a document.</rdfs:comment>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/ThesisDegree -->
+
+    <owl:Class rdf:about="http://purl.org/ontology/bibo/ThesisDegree">
+
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#AcademicDegree"/>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Different from general academic degree, thesis degree is achieved through one&apos;s completed thesis. Thesis is a document submitted in support of candidature for a degree or professional qualification presenting the author&apos;s research and findings(http://en.wikipedia.org/wiki/Thesis_or_dissertation).</obo:IAO_0000112>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Doctor of Philosophy (Ph.D.)</obo:IAO_0000112>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The academic degree of a Thesis.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
+        <rdfs:comment xml:lang="en">The academic degree of a Thesis</rdfs:comment>
+        <ns:term_status>stable</ns:term_status>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#AcademicDegree -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#AcademicDegree">
+
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An academic degree at any level, both as reported by individuals for employment and as offered by academic degree programs.</obo:IAO_0000115>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B.A. Bachelor of Arts</obo:IAO_0000112>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This list may have multiple abbreviations for some degrees.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#Award -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#Award">
+
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An Award or Honor</obo:IAO_0000112>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An Award or Honor</obo:IAO_0000115>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Wiley Prize in Biomedical Sciences</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#Certificate -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#Certificate">
+
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#Credential"/>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A document confirming certain characteristics of a person or organization, usually provided by some form of external review, education, or assessment.</obo:IAO_0000112>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A document confirming certain characteristics of a person or organization, usually provided by some form of external review, education, or assessment.</obo:IAO_0000115>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#Credential -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#Credential">
+
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An attestation of qualification, competence, or authority issued to an individual by a third party with a relevant or  de facto authority or assumed competence to do so.</obo:IAO_0000115>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An attestation of qualification, competence, or authority issued to an individual by a third party with a relevant or  de facto authority or assumed competence to do so.</obo:IAO_0000112>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#DateTimeValuePrecision -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#DateTimeValuePrecision">
+
+        <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Indicates the precision of the value of a DateTimeValue instance.</obo:IAO_0000115>
+    </owl:Class>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#License -->
+
+    <owl:Class rdf:about="http://vivoweb.org/ontology/core#License">
+
+        <rdfs:subClassOf rdf:resource="http://vivoweb.org/ontology/core#Credential"/>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Licenses are usually issued in order to regulate some activity that is deemed to be dangerous or a threat to the person or the public or which involves a high level of specialized skill.  See also core:Licensure.</obo:IAO_0000112>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Official or legal permission to do something</obo:IAO_0000115>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/ontology/bibo/accepted -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/accepted">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/draft -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/draft">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/peerReviewed -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/peerReviewed">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/published -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/published">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/rejected -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/rejected">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://purl.org/ontology/bibo/unpublished -->
+
+    <owl:NamedIndividual rdf:about="http://purl.org/ontology/bibo/unpublished">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#inPress -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#inPress">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#invited -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#invited">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#submitted -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#submitted">
+        <rdf:type rdf:resource="http://purl.org/ontology/bibo/DocumentStatus"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#yearMonthDayPrecision -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#yearMonthDayPrecision">
+        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValuePrecision"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#yearMonthDayTimePrecision -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#yearMonthDayTimePrecision">
+        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValuePrecision"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#yearMonthPrecision -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#yearMonthPrecision">
+        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValuePrecision"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://vivoweb.org/ontology/core#yearPrecision -->
+
+    <owl:NamedIndividual rdf:about="http://vivoweb.org/ontology/core#yearPrecision">
+        <rdf:type rdf:resource="http://vivoweb.org/ontology/core#DateTimeValuePrecision"/>
+    </owl:NamedIndividual>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 3.3.1957) http://owlapi.sourceforge.net -->
+

--- a/settings.xml.setup-dev
+++ b/settings.xml.setup-dev
@@ -7,7 +7,7 @@
             <properties>
                 <app-name>vivo</app-name>
 
-                <vivo-dir>/usr/local/vivo/vivo-19-base/vdata</vivo-dir>
+                <vivo-dir>/usr/local/vivo/vivo-cub-setup-dev/vdata</vivo-dir>
                 <tomcat-dir>/usr/local/tomcat.local/tomcat-cub-setup</tomcat-dir>
                 <vivo-installer-dir>../vivo-cuboulder</vivo-installer-dir>
                 <default-theme>wilma</default-theme>


### PR DESCRIPTION
the settings.xml.setup-dev file is unrelated to the fix, just saving a config file.
This fix changes has_honored_member from a faux property to just a regular object property listviewConfig.

In the long run we might want to have the code use the relates property and have sparql traverse through positions and awardrecipients to get the data, but it's not urgent.