### PR TITLE
Feature 5657

### DIFF
--- a/home/src/main/resources/rdf/display/everytime/fisPropertyConfig.n3
+++ b/home/src/main/resources/rdf/display/everytime/fisPropertyConfig.n3
@@ -1,0 +1,53 @@
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix : <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration#> .
+@prefix display: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix datagetter: <java:edu/cornell/mannlib/vitro/webapp/utils/datagetter/> .
+@prefix vitro: <http://vitro.mannlib.cornell.edu/ns/vitro/0.7#> .
+@prefix role:  <http://vitro.mannlib.cornell.edu/ns/vitro/role#> .
+@prefix local: <http://vitro.mannlib.cornell.edu/ns/vitro/siteConfig/> .
+@prefix vivo: <http://vivoweb.org/ontology/core#> . 
+@prefix obo: <http://purl.obolibrary.org/obo/> .
+
+@base <http://vitro.mannlib.cornell.edu/ns/vitro/ApplicationConfiguration> .
+
+
+# warning: don't use blank nodes; the display model doesn't currently support them.
+
+### roles using the teacher role property ###
+
+local:personHasTeacherRoleContext a :ConfigContext ;
+    :hasConfiguration local:personHasTeacherRoleConfig ;
+    :configContextFor <http://purl.obolibrary.org/obo/RO_0000053> ;
+    :qualifiedByDomain  <http://xmlns.com/foaf/0.1/Person>  ;
+    :qualifiedBy      <http://vivoweb.org/ontology/core#TeacherRole> .
+
+local:personHasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
+    :listViewConfigFile "listViewConfig-personHasTeacherRole.xml"^^xsd:string ;
+    rdfs:label "hasTeacherRole"@en-US;
+    :displayName "courses taught" ;
+    vitro:displayRankAnnot 20;
+    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
+    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
+    vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;
+    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.AddTeacherRoleToPersonGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupteaching> .
+
+
+local:teacherRoleContext a :ConfigContext ;
+    :hasConfiguration local:teacherRoleConfig ;
+    :configContextFor <http://purl.obolibrary.org/obo/BFO_0000055> ;
+    :qualifiedByDomain      <http://vivoweb.org/ontology/core#Course> ;
+    :qualifiedBy      vivo:TeacherRole .
+
+local:teacherRoleConfig a :ObjectPropertyDisplayConfig ;
+    :listViewConfigFile "listViewConfig-teacherRole.xml"^^xsd:string ;
+    rdfs:label "relatedRole"@en-US;
+    :displayName "instructor(s)" ;
+    vitro:displayRankAnnot 17;
+    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
+    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
+    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ProjectHasParticipantGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .

--- a/home/src/main/resources/rdf/display/everytime/fisPropertyConfig.n3
+++ b/home/src/main/resources/rdf/display/everytime/fisPropertyConfig.n3
@@ -26,7 +26,7 @@ local:personHasTeacherRoleContext a :ConfigContext ;
 
 local:personHasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
     :listViewConfigFile "listViewConfig-personHasTeacherRole.xml"^^xsd:string ;
-    rdfs:label "hasTeacherRole"@en-US;
+    rdfs:label "personHasTeacherRole"@en-US;
     :displayName "courses taught" ;
     vitro:displayRankAnnot 20;
     vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
@@ -36,15 +36,15 @@ local:personHasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
     :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupteaching> .
 
 
-local:teacherRoleContext a :ConfigContext ;
-    :hasConfiguration local:teacherRoleConfig ;
+local:courseHasTeacherRoleContext a :ConfigContext ;
+    :hasConfiguration local:courseHasTeacherRoleConfig ;
     :configContextFor <http://purl.obolibrary.org/obo/BFO_0000055> ;
     :qualifiedByDomain      <http://vivoweb.org/ontology/core#Course> ;
     :qualifiedBy      vivo:TeacherRole .
 
-local:teacherRoleConfig a :ObjectPropertyDisplayConfig ;
-    :listViewConfigFile "listViewConfig-teacherRole.xml"^^xsd:string ;
-    rdfs:label "relatedRole"@en-US;
+local:courseHasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
+    :listViewConfigFile "listViewConfig-courseHasTeacherRole.xml"^^xsd:string ;
+    rdfs:label "courseHasTeacherRole"@en-US;
     :displayName "instructor(s)" ;
     vitro:displayRankAnnot 17;
     vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;

--- a/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
+++ b/home/src/main/resources/rdf/display/firsttime/PropertyConfig.n3
@@ -208,22 +208,26 @@ local:orgHasMemberRoleConfig a :ObjectPropertyDisplayConfig ;
     vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.AddMemberRoleToPersonGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
     :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupaffiliation> .
 
-local:hasTeacherRoleContext a :ConfigContext ;
-    :hasConfiguration local:hasTeacherRoleConfig ;
-    :configContextFor <http://purl.obolibrary.org/obo/RO_0000053> ;
-    :qualifiedByDomain  <http://xmlns.com/foaf/0.1/Person>  ;
-    :qualifiedBy      <http://vivoweb.org/ontology/core#TeacherRole> .
-
-local:hasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
-    :listViewConfigFile "listViewConfig-roleRealizedIn.xml"^^xsd:string ;
-    rdfs:label "hasTeacherRole"@en-US;
-    :displayName "teaching activities" ;
-    vitro:displayRankAnnot 20;
-    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
-    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
-    vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;
-    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.AddTeacherRoleToPersonGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupteaching> .
+#
+# DRE 2018/12/19 - Commented out this faux property on realizes. Handling roles directly on the role subclass, like TeacherRole, directly with it's own listviewConfig
+#                  This is in display/everytime/fisPropertyConfig.n3
+#
+#local:hasTeacherRoleContext a :ConfigContext ;
+#    :hasConfiguration local:hasTeacherRoleConfig ;
+#    :configContextFor <http://purl.obolibrary.org/obo/RO_0000053> ;
+#    :qualifiedByDomain  <http://xmlns.com/foaf/0.1/Person>  ;
+#    :qualifiedBy      <http://vivoweb.org/ontology/core#TeacherRole> .
+#
+#local:hasTeacherRoleConfig a :ObjectPropertyDisplayConfig ;
+#    :listViewConfigFile "listViewConfig-roleRealizedIn.xml"^^xsd:string ;
+#    rdfs:label "hasTeacherRole"@en-US;
+#    :displayName "teaching activities" ;
+#    vitro:displayRankAnnot 20;
+#    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
+#    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
+#    vitro:stubObjectPropertyAnnot "true"^^xsd:boolean ;
+#    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.AddTeacherRoleToPersonGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
+#    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupteaching> .
 
 local:hasEditorRoleContext a :ConfigContext ;
     :hasConfiguration local:hasEditorRoleConfig ;
@@ -1906,21 +1910,24 @@ local:addressLocationConfig a :ObjectPropertyDisplayConfig ;
     :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGrouplocation> .
 
 ### roles using the BFO_0000055 property ###
-
-local:bfo_0000055Context a :ConfigContext ;
-    :hasConfiguration local:bfo_0000055Config ;
-    :configContextFor <http://purl.obolibrary.org/obo/BFO_0000055> ;
-    :qualifiedBy      <http://purl.obolibrary.org/obo/BFO_0000023> .
-
-local:bfo_0000055Config a :ObjectPropertyDisplayConfig ;
-    :listViewConfigFile "listViewConfig-relatedRole.xml"^^xsd:string ;
-    rdfs:label "relatedRole"@en-US;
-    :displayName "participant" ;
-    vitro:displayRankAnnot 17;
-    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
-    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
-    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ProjectHasParticipantGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
+#
+# DRE 2018/12/19 - Commented out generic role faux property on realizes. Handling roles directly on the role subclass, like TeacherRole, directly with it's own listviewConfig
+#                  This is in display/everytime/fisPropertyConfig.n3
+#
+#local:bfo_0000055Context a :ConfigContext ;
+#    :hasConfiguration local:bfo_0000055Config ;
+#    :configContextFor <http://purl.obolibrary.org/obo/BFO_0000055> ;
+#    :qualifiedBy      <http://purl.obolibrary.org/obo/BFO_0000023> .
+#
+#local:bfo_0000055Config a :ObjectPropertyDisplayConfig ;
+#    :listViewConfigFile "listViewConfig-relatedRole.xml"^^xsd:string ;
+#    rdfs:label "relatedRole"@en-US;
+#    :displayName "participant" ;
+#    vitro:displayRankAnnot 17;
+#    vitro:hiddenFromDisplayBelowRoleLevelAnnot role:public ;
+#    vitro:prohibitedFromUpdateBelowRoleLevelAnnot role:public ;
+#    vitro:customEntryFormAnnot "edu.cornell.mannlib.vitro.webapp.edit.n3editing.configuration.generators.ProjectHasParticipantGenerator"^^<http://www.w3.org/2001/XMLSchema#string> ;
+#    :propertyGroup <http://vivoweb.org/ontology#vitroPropertyGroupoverview> .
 
 ### grant roles using the core:relates property ###
 

--- a/webapp/src/main/webapp/config/listViewConfig-courseHasTeacherRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-courseHasTeacherRole.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<!-- See guidelines at https://wiki.duraspace.org/x/eYXVAw -->
+
+
+<list-view-config>
+    <query-select>    
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX afn:  &lt;http://jena.hpl.hp.com/ARQ/function#&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        
+        SELECT DISTINCT <collated>?subclass</collated>
+						?vSubclass
+                        # send the property to the template, since this view supports multiple role properties
+                        ?property
+                        ?role   
+                        ?roleLabel ?roleTypeLabel                          
+                        ?indivInRole (afn:localname(?indivInRole) AS ?indivName)
+                        ?indivLabel
+                        ?dateTimeInterval ?dateTimeStart ?dateTimeEnd ?objectType
+        WHERE {
+                        
+            ?subject ?property ?role .
+            ?role a ?objectType
+
+            OPTIONAL { ?role rdfs:label ?roleLabel }
+
+            # We need ?subclass in the uncollated query to get the roleTypeLabel  
+            # for roles that have no label.
+            OPTIONAL { ?role vitro:mostSpecificType ?subclass . }
+            OPTIONAL { ?role vitro:mostSpecificType ?subclass .
+                       ?subclass rdfs:label ?roleTypeLabel 
+            }
+            OPTIONAL { ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole }
+            OPTIONAL { ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+                       ?indivInRole rdfs:label ?indivLabel 
+            }
+            OPTIONAL { ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+                       ?indivInRole a vcard:Kind .                      
+			           ?indivInRole vcard:hasName ?vName .
+			           ?vName vcard:familyName ?lastName .
+			           OPTIONAL { ?vName vcard:givenName ?firstName . }
+			           OPTIONAL { ?vName core:middleName ?middleName . }
+					   bind ( COALESCE(?firstName, "") As ?firstName1) .
+			           bind ( COALESCE(?middleName, "") As ?middleName1) .
+			           bind ( COALESCE(?lastName, "") As ?lastName1) .
+			           bind (concat(str(?lastName1 + ", "),str(?firstName1 + " "),str(?middleName1)) as ?indivLabel) .
+             
+            		OPTIONAL { ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+                       	?indivInRole a vcard:Kind .  
+                       	?indivInRole vitro:mostSpecificType ?vSubclass .
+                       	?vSubclass rdfs:subClassOf vcard:Kind 
+            		}
+ 			}
+            OPTIONAL { ?role core:dateTimeInterval ?dateTimeInterval .
+                       ?dateTimeInterval core:start ?dateTimeStartValue .                    
+                       ?dateTimeStartValue core:dateTime ?dateTimeStart 
+            }
+            OPTIONAL { ?role core:dateTimeInterval ?dateTimeInterval .
+                       ?dateTimeInterval core:end ?dateTimeEndValue .
+                       ?dateTimeEndValue core:dateTime ?dateTimeEnd
+            }
+            <critical-data-required>
+            FILTER ( bound(?indivInRole) )
+            </critical-data-required>     
+        } ORDER BY <collated>?subclass</collated> ?indivLabel ?roleLabel ?roleTypeLabel ?indivName
+    </query-select>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;    
+        CONSTRUCT { 
+            ?subject ?property ?role .
+            ?role a ?objectType .
+            ?role rdfs:label ?roleLabel .
+            ?role vitro:mostSpecificType ?subclass .
+            ?subclass rdfs:label ?roleTypeLabel .
+            ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+            ?indivInRole rdfs:label ?indivLabel
+        } WHERE {
+            {
+               ?subject ?property ?role .
+               ?role a ?objectType 
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role rdfs:label ?roleLabel  
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role vitro:mostSpecificType ?subclass 
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role vitro:mostSpecificType ?subclass . 
+               ?subclass rdfs:label ?roleTypeLabel
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+               ?indivInRole rdfs:label ?indivLabel
+            }
+        } 
+    </query-construct>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;    
+        PREFIX vcard:  &lt;http://www.w3.org/2006/vcard/ns#&gt;
+        CONSTRUCT { 
+            ?subject ?property ?role .
+            ?role a ?objectType .
+            ?role rdfs:label ?roleLabel .
+            ?role vitro:mostSpecificType ?subclass .
+            ?subclass rdfs:label ?roleTypeLabel .
+            ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+            ?indivInRole a vcard:Kind .
+            ?indivInRole vcard:hasName ?vName .
+            ?vName vcard:familyName ?lastName . 
+            ?vName vcard:givenName ?firstName . 
+			?vName core:middleName ?middleName .
+            ?indivInRole vitro:mostSpecificType ?vSubclass .
+            ?vSubclass rdfs:subClassOf vcard:Kind          
+        } WHERE {
+            {
+               ?subject ?property ?role .
+               ?role a ?objectType 
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role rdfs:label ?roleLabel  
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role vitro:mostSpecificType ?subclass 
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role vitro:mostSpecificType ?subclass . 
+               ?subclass rdfs:label ?roleTypeLabel
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+               ?indivInRole a vcard:Kind .                      
+               ?indivInRole vcard:hasName ?vName .
+               ?vName vcard:familyName ?lastName .  
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+               ?indivInRole a vcard:Kind .                      
+               ?indivInRole vcard:hasName ?vName .
+               ?vName vcard:familyName ?lastName . 
+               ?vName vcard:givenName ?firstName . 
+            } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+               ?indivInRole a vcard:Kind .                      
+               ?indivInRole vcard:hasName ?vName .
+               ?vName vcard:familyName ?lastName . 
+               ?vName vcard:givenName ?firstName . 
+			   ?vName core:middleName ?middleName .
+	        } UNION {
+               ?subject ?property ?role .
+               ?role a ?objectType .
+               ?role &lt;http://purl.obolibrary.org/obo/RO_0000052&gt; ?indivInRole .
+               ?indivInRole a vcard:Kind .
+               ?indivInRole vitro:mostSpecificType ?vSubclass .
+               ?vSubclass rdfs:subClassOf vcard:Kind
+            }
+        } 
+    </query-construct>
+    
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;   
+        CONSTRUCT { 
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:start ?dateTimeStartValue .
+            ?dateTimeStartValue core:dateTime ?dateTimeStart 
+        } WHERE {
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:start ?dateTimeStartValue .
+            ?dateTimeStartValue core:dateTime ?dateTimeStart 
+        } 
+    </query-construct>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;    
+        CONSTRUCT { 
+            ?subject ?property ?role .  
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:end ?dateTimeEndValue .
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd 
+        } WHERE {
+            ?subject ?property ?role .  
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:end ?dateTimeEndValue .
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd 
+        } 
+    </query-construct>
+
+    <template>propStatement-courseHasTeacherRole.ftl</template>
+</list-view-config>

--- a/webapp/src/main/webapp/config/listViewConfig-personHasTeacherRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-personHasTeacherRole.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<!-- See guidelines at https://wiki.duraspace.org/x/eYXVAw -->
+
+<list-view-config>
+    <query-select>    
+        PREFIX core:  &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        
+        SELECT DISTINCT <collated>?subclass</collated>
+                        # send the property to the template, since this view supports multiple role properties
+                        ?property
+                        ?role 
+                        ?roleLabel 
+                        ?roleDesc
+                        ?activity ?activityName 
+                        ?activityLabel
+                        ?activityDesc
+                        ?dateTimeStart ?dateTimeEnd 
+                        ?hideThis
+                        ?objectType
+        WHERE {                
+            ?subject ?property ?role .
+            ?role a ?objectType .
+            
+            OPTIONAL {  ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?activity .
+                        ?activity rdfs:label ?activityLabel .
+                        ?activity core:description ?activityDesc .
+                        
+                        <collated>
+                        ?activity vitro:mostSpecificType ?subclass   
+                        </collated>
+            }           
+            OPTIONAL { ?role rdfs:label ?roleLabel }
+            OPTIONAL { ?role core:description ?roleDesc } 
+            OPTIONAL { ?role core:dateTimeInterval ?dateTimeInterval .
+                       ?dateTimeInterval core:start ?dateTimeStartValue .
+                       ?dateTimeStartValue core:dateTime ?dateTimeStart 
+            }
+            OPTIONAL { ?role core:dateTimeInterval ?dateTimeInterval .
+                       ?dateTimeInterval core:end ?dateTimeEndValue .
+                       ?dateTimeEndValue core:dateTime ?dateTimeEnd 
+            }
+        } ORDER BY <collated>?subclass</collated> DESC(?dateTimeEnd) DESC(?dateTimeStart) ?activityLabel ?activityName
+    </query-select>
+    
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;  
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;          
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        
+        CONSTRUCT {
+            ?subject ?property ?role .
+            ?role a ?objectType .
+            ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?activity .
+            ?activity vitro:mostSpecificType ?subclass .
+        } WHERE {
+            ?subject ?property ?role .
+            ?role a ?objectType .
+            ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?activity .
+            ?activity vitro:mostSpecificType ?subclass
+        }
+    </query-construct>
+    
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;    
+        CONSTRUCT { 
+            ?subject ?property ?role .
+            ?role rdfs:label ?roleLabel . 
+            ?role core:description ?roleDesc . 
+    	    ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?activity . 
+ 	    ?role core:roleContributesTo ?activity .
+            ?activity rdfs:label ?activityName .
+            ?activity core:description ?activityDesc
+        } WHERE {
+            {
+                ?subject ?property ?role .
+                ?role a ?objectType .
+            } UNION {
+                ?subject ?property ?role .
+                ?role a ?objectType .
+                ?role rdfs:label ?roleLabel . 
+                ?role core:description ?roleDesc . 
+            } UNION {
+                ?subject ?property ?role .
+                ?role a ?objectType .
+                ?role core:relates ?activity . 
+                ?activity rdfs:label ?activityName 
+            } UNION {
+                ?subject ?property ?role .
+                ?role a ?objectType .
+                ?role &lt;http://purl.obolibrary.org/obo/BFO_0000054&gt; ?activity . 
+                ?activity rdfs:label ?activityName .
+                ?activity core:description ?activityDesc
+
+            } UNION {
+                ?subject ?property ?role .
+                ?role a ?objectType .
+                ?role core:roleContributesTo ?activity .
+                ?activity rdfs:label ?activityName
+            }
+        } 
+    </query-construct>
+        
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;   
+        CONSTRUCT { 
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:start ?dateTimeStartValue .
+            ?dateTimeStartValue core:dateTime ?dateTimeStart 
+        } WHERE {
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:start ?dateTimeStartValue .
+            ?dateTimeStartValue core:dateTime ?dateTimeStart 
+        } 
+    </query-construct>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;   
+        CONSTRUCT { 
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:end ?dateTimeEndValue .
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd 
+        } WHERE {
+            ?subject ?property ?role .  
+            ?role a ?objectType .
+            ?role core:dateTimeInterval ?dateTimeInterval .
+            ?dateTimeInterval core:end ?dateTimeEndValue .
+            ?dateTimeEndValue core:dateTime ?dateTimeEnd 
+        } 
+    </query-construct>
+
+    <template>propStatement-personTeacherRoles.ftl</template>
+</list-view-config>

--- a/webapp/src/main/webapp/config/listViewConfig-personHasTeacherRole.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-personHasTeacherRole.xml
@@ -139,5 +139,5 @@
         } 
     </query-construct>
 
-    <template>propStatement-personTeacherRoles.ftl</template>
+    <template>propStatement-personHasTeacherRoles.ftl</template>
 </list-view-config>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-courseHasTeacherRole.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-courseHasTeacherRole.ftl
@@ -49,5 +49,5 @@
         </#if>
     </#local>
 
-    ${linkedIndividual}&nbsp;${roleLabel!}&nbsp;${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
+    ${linkedIndividual}&nbsp;${roleLabel!}
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-courseHasTeacherRole.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-courseHasTeacherRole.ftl
@@ -1,0 +1,53 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- 
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+
+<#import "lib-sequence.ftl" as s>
+<#import "lib-datetime.ftl" as dt>
+
+<@showRole statement property  />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showRole statement property >
+  
+    <#local linkedIndividual>
+        <#if statement.indivInRole??>
+    		<#if statement.vSubclass?? && statement.vSubclass?contains("vcard")>
+				<#if statement.indivLabel?replace(" ","")?length == statement.indivLabel?replace(" ","")?last_index_of(",") + 1 >
+        			${statement.indivLabel?replace(",","")}
+				<#else>
+					${statement.indivLabel}
+				</#if>
+    		<#else>
+        			<a href="${profileUrl(statement.uri("indivInRole"))}" title="${i18n().name}">${statement.indivLabel!statement.indivName}</a>
+    		</#if>
+        <#else>
+            <#-- This shouldn't happen, but we must provide for it -->
+            <a href="${profileUrl(statement.uri("role"))}"  title="${i18n().missing_person_in_role}">${i18n().missing_person_in_role}</a>
+        </#if>
+    </#local>
+
+    <#-- 
+         Generally roles are assigned a label when entered through a custom form. Investigator and its subclasses do not,
+         so use the type label instead if not collated by subclass.
+    -->
+    <#local roleLabel>
+       
+        <#if statement.roleTypeLabel?has_content>
+            <#assign roleTypeLabel = statement.roleTypeLabel!"" >
+		<#else>
+			<#assign roleTypeLabel = "" >
+        </#if>
+        <#if statement.roleLabel??>
+            ${statement.roleLabel?replace(" Role", "")?replace(" role","")}
+        <#elseif !property.collatedBySubclass >
+            ${roleTypeLabel?replace(" Role", "")}
+        </#if>
+    </#local>
+
+    ${linkedIndividual}&nbsp;${roleLabel!}&nbsp;${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
+</#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personHasTeacherRoles.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personHasTeacherRoles.ftl
@@ -37,6 +37,6 @@
     </#local>
 
     
-    ${linkedIndividual} ${statement.activityDesc!} ${"("} ${statement.roleDesc!} ${")"} ${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
+    ${linkedIndividual}  ${statement.activityDesc!} ${statement.roleDesc!} ${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
 </#if>
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personHasTeacherRoles.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personHasTeacherRoles.ftl
@@ -34,9 +34,11 @@
     
     <#local dateTime>
         <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" />
+<#-- next line is for year month precision -->
+<#--        ${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} -->
     </#local>
 
     
-    ${linkedIndividual}  ${statement.activityDesc!} ${statement.roleDesc!} ${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
+    ${linkedIndividual}  ${statement.activityDesc!} ${statement.roleDesc!} 
 </#if>
 </#macro>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personTeacherRoles.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-personTeacherRoles.ftl
@@ -1,0 +1,42 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- Custom object property statement view for the roleRealizedIn, roleContributesTo, researchActivities, hasRole 
+     and hasClinicalActivities custom list views. See those list view and the PropertyConfig.n3 file for details.
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+
+<#import "lib-datetime.ftl" as dt>
+<@showRole statement />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showRole statement>
+<#if statement.hideThis?has_content>
+    <span class="hideThis">&nbsp;</span>
+    <script type="text/javascript" >
+        $('span.hideThis').parent().parent().addClass("hideThis");
+        if ( $('h3#RO_0000053-ResearcherRole').attr('class').length == 0 ) {
+            $('h3#RO_0000053-ResearcherRole').addClass('hiddenGrants');
+        }
+        $('span.hideThis').parent().remove();
+    </script>
+<#else>
+    <#local linkedIndividual>
+        <#if statement.activity??>
+            <a href="${profileUrl(statement.uri("activity"))}" title="${i18n().activity_name}">${statement.activityLabel!statement.activityName}</a>
+        <#else>
+            <#-- This shouldn't happen, but we must provide for it -->
+            <a href="${profileUrl(statement.uri("role"))}" title="${i18n().missing_activity}">${i18n().missing_activity}</a>
+        </#if>
+    </#local>
+    
+    <#local dateTime>
+        <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" />
+    </#local>
+
+    
+    ${linkedIndividual} ${statement.activityDesc!} ${"("} ${statement.roleDesc!} ${")"} ${dt.dateTimeIntervalShort(statement.dateTimeStart, "yearMonthPrecision", statement.dateTimeEnd, "yearMonthPrecision", true)!} 
+</#if>
+</#macro>


### PR DESCRIPTION
Vivo components to add courses taught to experts.
This comments out functionality from stock VIVO for generic roles and replaces it with custom functionality for the TeacherRole property.
This has been developed on vivo-cub-dev and then deployed to vivo-cub-setup.
Deployment steps require removal of the tdbModels directory such that the firsttime files are re-read.
This has also been tested against vivo-cub-setup
