### PR TITLE
check for experts.colorado.edu before executing google analytics

### DIFF
--- a/webapp/src/main/webapp/themes/cu-boulder/templates/googleAnalytics.ftl
+++ b/webapp/src/main/webapp/themes/cu-boulder/templates/googleAnalytics.ftl
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 <script type="text/javascript">  
+if (document.location.hostname.search("experts.colorado.edu") !== -1) {
  var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-34751034-1']);
   _gaq.push(['_trackPageview']);
@@ -39,5 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
+}
 </script>
 


### PR DESCRIPTION
Prior to this PR, google analytics was executed for all CU VIVO systems.
Found a recommendation on stackoverflow to address this:
https://stackoverflow.com/questions/1251922/is-there-a-way-to-stop-google-analytics-counting-development-work-as-hits
This change checks if the serving host is the desired host ( experts.colorado.edu) for analytics and executes code if it is.
Tested this on dev and production ( in the tomcat running code ) and google real time analytics responds appropriately for positive and negative tests.