### PR TITLE
wush 5767 - statistics - stop line wrap, show courses, remove locations

### DIFF
--- a/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page.ftl
@@ -71,7 +71,7 @@
                         <#if !firstPopulatedClassGroup??>
                             <#assign firstPopulatedClassGroup = group />
                         </#if>
-                        <#if !group.uri?contains("equipment") && !group.uri?contains("course") >
+                        <#if !group.uri?contains("events") && !group.uri?contains("location") >
                             <li>
                                 <a href="${urls.base}/browse">
                                     <p  class="stats-count">


### PR DESCRIPTION
Courses showed under the Events class group and the line wrapped.
Fixed the line wrap by removing locations.
Changed the exception in the code to exclude events instead of courses.
Deployed to vivo-cub-dev.