### PR TITLE
Changes for CU Scholar Open Access Link

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
@@ -65,3 +65,23 @@ pubs:bookTitle
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
       vitro:publicDescriptionAnnot "book title"^^xsd:string ;
       vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
+
+pubs:cuscholar
+      a       owl:DatatypeProperty ;
+      rdfs:label "Open Access Copy"@en-US ;
+      rdfs:range xsd:anyURI ;
+      vitro:displayLimitAnnot
+              "1"^^xsd:int ;
+      vitro:displayRankAnnot
+              "4"^^xsd:int ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:hiddenFromPublishBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot
+              <http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot
+              <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:publicDescriptionAnnot
+              "Link to CU Scholar Open Access site"^^xsd:string .
+

--- a/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-authorInAuthorship.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<!-- See guidelines at https://wiki.duraspace.org/x/eYXVAw -->
+
+<list-view-config>
+    <query-select>
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+        PREFIX pubs: &lt;https://experts.colorado.edu/ontology/pubs#&gt;
+
+        SELECT DISTINCT ?subclass
+            ?authorship
+            ?infoResource ?infoResourceName
+            ?dateTime
+            ?journal
+            ?volume
+            ?startPage
+            ?endPage
+            ?cuscholar
+            ?doi
+            ?pmid
+            ?isbn10
+            ?isbn13
+            ?publisher
+            ?locale
+            ?appearsIn
+            ?partOf
+            ?editor
+            ?hideThis
+        WHERE
+        {
+            ?subject ?property ?authorship .
+            ?authorship a core:Authorship .
+            ?authorship core:relates ?infoResource .
+            ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+            ?infoResource rdfs:label ?infoResourceName .
+            OPTIONAL { ?infoResource vitro:mostSpecificType ?subclass }
+            OPTIONAL { ?infoResource bibo:volume ?volume }
+            OPTIONAL { ?infoResource bibo:pageStart ?startPage }
+            OPTIONAL { ?infoResource bibo:pageEnd ?endPage }
+            OPTIONAL { ?infoResource bibo:doi ?doi }
+            OPTIONAL { ?infoResource pubs:cuscholar ?cuscholar }
+            OPTIONAL { ?infoResource bibo:pmid ?pmid }
+            OPTIONAL { ?infoResource bibo:isbn10 ?isbn10 }
+            OPTIONAL { ?infoResource bibo:isbn13 ?isbn13 }
+            OPTIONAL { ?infoResource core:placeOfPublication ?locale }
+            OPTIONAL
+            {
+                ?infoResource bibo:reproducedIn ?appearsInObj .
+                ?appearsInObj rdfs:label ?appearsIn .
+            }
+            OPTIONAL
+            {
+                ?infoResource core:publisher ?publisherObj .
+                ?publisherObj rdfs:label ?publisher .
+            }
+            OPTIONAL
+            {
+                ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
+                ?partOfObj rdfs:label ?partOf .
+            }
+            OPTIONAL
+            {
+                ?infoResource core:hasPublicationVenue ?publishedIn .
+                ?publishedIn  rdfs:label ?journal .
+            }
+            OPTIONAL
+            {
+                ?infoResource core:dateTimeValue ?dateTimeValue .
+                ?dateTimeValue core:dateTime ?dateTime .
+            }
+            OPTIONAL
+            {
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorObj .
+                ?editorObj rdfs:label ?editor .
+            }
+            OPTIONAL { ?authorship core:hideFromDisplay ?hideThis }
+        } ORDER BY ?subclass  DESC(?dateTime) ?infoResourceName
+    </query-select>
+
+    <query-construct>
+        PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
+        PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+        PREFIX bibo: &lt;http://purl.org/ontology/bibo/&gt;
+        PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;
+        PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
+        PREFIX pubs: &lt;https://experts.colorado.edu/ontology/pubs#&gt;
+        CONSTRUCT
+        {
+            ?subject ?property ?authorship .
+            ?authorship a core:Authorship .
+            ?authorship core:hideFromDisplay ?hideThis .
+            ?authorship core:relates ?infoResource .
+            ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+            ?infoResource vitro:mostSpecificType ?subclass .
+            ?infoResource rdfs:label ?infoResourceName .
+            ?infoResource bibo:volume ?volume .
+            ?infoResource bibo:pageStart ?startPage .
+            ?infoResource bibo:pageEnd ?endPage .
+            ?infoResource bibo:doi ?doi .
+            ?infoResource pubs:cuscholar ?cuscholar .
+            ?infoResource bibo:pmid ?pmid .
+            ?infoResource bibo:isbn10 ?isbn10 .
+            ?infoResource bibo:isbn13 ?isbn13 .
+            ?infoResource core:placeOfPublication ?locale .
+            ?infoResource bibo:reproducedIn ?appearsInObj .
+            ?appearsInObj rdfs:label ?appearsIn .
+
+            ?infoResource core:publisher ?publisherObj .
+            ?publisherObj rdfs:label ?publisher .
+
+            ?infoResource core:hasPublicationVenue ?publishedIn .
+            ?publishedIn  rdfs:label ?journal .
+
+            ?infoResource core:dateTimeValue ?dateTimeValue .
+            ?dateTimeValue core:dateTime ?dateTime .
+
+            ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
+            ?partOfObj rdfs:label ?partOf .
+
+            ?infoResource core:relatedBy ?editorship .
+            ?editorship a core:Editorship .
+            ?editorship core:relates ?editorObj .
+            ?editorObj a foaf:Person .
+            ?editorObj rdfs:label ?editor .
+        }
+        WHERE
+        {
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:hideFromDisplay ?hideThis .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource vitro:mostSpecificType ?subclass .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource rdfs:label ?infoResourceName
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:volume ?volume .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:pageStart ?startPage .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:pageEnd ?endPage .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:doi ?doi .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource pubs:cuscholar ?cuscholar .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:pmid ?pmid .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:isbn10 ?isbn10 .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:isbn13 ?isbn13 .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource core:placeOfPublication ?locale .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource bibo:reproducedIn ?appearsInObj .
+                ?appearsInObj rdfs:label ?appearsIn .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource core:publisher ?publisherObj .
+                ?publisherObj rdfs:label ?publisher .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource core:dateTimeValue ?dateTimeValue .
+                ?dateTimeValue core:dateTime ?dateTime .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource core:hasPublicationVenue ?publishedIn .
+                ?publishedIn  rdfs:label ?journal .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a &lt;http://purl.obolibrary.org/obo/IAO_0000030&gt; .
+                ?infoResource &lt;http://purl.obolibrary.org/obo/BFO_0000050&gt; ?partOfObj .
+                ?partOfObj rdfs:label ?partOf .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a bibo:Book .
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorObj .
+                ?editorObj a foaf:Person .
+                ?editorObj rdfs:label ?editor .
+            }
+            UNION
+            {
+                ?subject ?property ?authorship .
+                ?authorship a core:Authorship .
+                ?authorship core:relates ?infoResource .
+                ?infoResource a bibo:BookSection .
+                ?infoResource core:relatedBy ?editorship .
+                ?editorship a core:Editorship .
+                ?editorship core:relates ?editorObj .
+                ?editorObj a foaf:Person .
+                ?editorObj rdfs:label ?editor .
+            }
+        }
+    </query-construct>
+
+    <template>propStatement-authorInAuthorship.ftl</template>
+</list-view-config>

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-authorInAuthorship.ftl
@@ -113,9 +113,10 @@
  
     <#local doi>
       <#if statement.doi??>
-        <a href="http://dx.doi.org/${statement.doi}" target="_blank">
-          <img src="https://img.shields.io/badge/Published%20Version--blue.svg">
-        </a>
+        <a href="http://dx.doi.org/${statement.doi}" target="_blank"><img src="https://img.shields.io/badge/Published%20Version--blue.svg"></a>
+      </#if>
+      <#if statement.cuscholar??>
+        <a href="${statement.cuscholar}" target="_blank"><img src="https://img.shields.io/badge/Open%20Access%20Copy--orange.svg"></a>
       </#if>
     </#local>
 


### PR DESCRIPTION
This PR adds a new data property call pubs:cuscholar to the CU pubs ontology.
It then localizes the file: listViewConfig-authorInAuthorship.xml from the VIVO repo into the vivo-cuboulder repo.
This is necessary because the pubs:cuscholar data property needs to be read as part of the listviewConfig.
Finally the propStatement-authorInAuthorship.ftl is updated to display the cuscholar link if a doi exists.
For now the cuscholar entry will only exist if there is a doi.
This depends on PR: https://github.com/cu-boulder/fis_harvestor_base/pull/24

Risk -- The display of a publication on the publications page is affected by the ontology changes and when entries are harvested. There is always a risk that the page would look bad. This has been tested.
     --- The display of all publications for the author on the persons page is also affected. 