### PR TITLE
award in org - broke out awardorg from award, added links for award a…

### DIFF
--- a/webapp/src/main/webapp/config/listViewConfig-awardInOrganization.xml
+++ b/webapp/src/main/webapp/config/listViewConfig-awardInOrganization.xml
@@ -11,6 +11,7 @@
         PREFIX vitro: &lt;http://vitro.mannlib.cornell.edu/ns/vitro/0.7#&gt;
         PREFIX obo:   &lt;http://purl.obolibrary.org/obo/&gt;
         PREFIX skos:  &lt;http://www.w3.org/2004/02/skos/core#&gt;
+        PREFIX vlocal: &lt;https://experts.colorado.edu/ontology/vivo-fis#&gt;
         
         SELECT DISTINCT
           <collated>?subclass</collated> 
@@ -18,6 +19,9 @@
             ?person
             ?personName
             ?dtv
+            ?orgid
+            ?orgname
+            ?award
         WHERE {
             ?subject ?property ?person .
             ?person rdfs:label ?personName .
@@ -25,6 +29,10 @@
             ?awardreceipt a core:AwardReceipt .
             ?awardreceipt core:relates ?award.
             ?awardreceipt core:dateTimeValue ?dt .
+            ?awardrecip core:assignedBy ?orgid .
+            ?orgid a vlocal:AwardingOrganization .
+            ?orgid rdfs:label ?orgname .
+            ?orgid core:assigns ?award .
             ?dt core:dateTime ?dtv .
             ?award a core:Award .
             ?award rdfs:label ?awardName .
@@ -40,12 +48,17 @@
         PREFIX core: &lt;http://vivoweb.org/ontology/core#&gt;
         PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
         PREFIX obo:   &lt;http://purl.obolibrary.org/obo/&gt;
+        PREFIX vlocal: &lt;https://experts.colorado.edu/ontology/vivo-fis#&gt;
         CONSTRUCT {
             ?subject ?property ?person .
             ?person core:relatedBy ?awardreceipt .
             ?awardreceipt a core:AwardReceipt .
             ?awardreceipt core:dateTimeValue ?dt .
             ?dt core:dateTime ?dtv .
+            ?awardrecip core:assignedBy ?orgid .
+            ?orgid a vlocal:AwardingOrganization .
+            ?orgid rdfs:label ?orgname .
+            ?orgid core:assigns ?award .
         } WHERE {
             ?subject ?property ?person .
             ?person rdfs:label ?personName .
@@ -53,6 +66,12 @@
             ?awardreceipt a core:AwardReceipt .
             ?awardreceipt core:dateTimeValue ?dt .
             ?dt core:dateTime ?dtv .
+            ?awardrecip core:assignedBy ?orgid .
+            ?orgid a vlocal:AwardingOrganization .
+            ?orgid rdfs:label ?orgname .
+            ?orgid core:assigns ?award .
+            ?awardreceipt core:relates ?award .
+            ?award a core:Award .
         } 
     </query-construct>
  

--- a/webapp/src/main/webapp/templates/freemarker/body/individual/individual-vitro.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/individual/individual-vitro.ftl
@@ -126,12 +126,15 @@ ${scripts.add('<script type="text/javascript" src="${urls.base}/js/imageUpload/i
         var type_ = info.attr('data-award-type');
         var url_ = info.attr('data-url');
         var award_name = info.attr('data-award-name');
+        var award_url = info.attr('data-award-url');
         var person_name = info.attr('data-person-name');
+        var award_org_name = info.attr('data-award-org-name');
+        var award_org_url = info.attr('data-award-org-url');
         var date_time = info.attr('data-date').substring(0,4);
 
         // If a DOM element doesn't exist for award yet, create one.
         if ($('#'+type_).length == 0) {
-            $('#has_honored_member-Person-List').append('<li class="subclass"><h3>'+award_name+'</h3><ul class="subclass-property-list" id="'+type_+'"></ul></li>');
+            $('#has_honored_member-Person-List').append('<li class="subclass"><h3><a href="'+award_url+'">'+award_name+'</a> conferred by <a href="'+award_org_url+'">'+award_org_name+'</a></h3><ul class="subclass-property-list" id="'+type_+'"></ul></li>');
         }
 
         // Add list element for each entry.

--- a/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-awardInOrganization.ftl
+++ b/webapp/src/main/webapp/templates/freemarker/body/partials/individual/propStatement-awardInOrganization.ftl
@@ -11,6 +11,6 @@
 
    <#-- Create invisible DOM element to store data in DOM. This is accessed by a javascript function in
         productMods/templates/freemarker/body/individual/individual-vitro.ftl -->
-   <span data-award-type="${award_type}" data-url="${profileUrl(statement.uri("person"))}" data-person-name="${statement.personName}" data-award-name="${statement.awardName}" data-date="${statement.dtv!}">
+   <span data-award-type="${award_type}" data-url="${profileUrl(statement.uri("person"))}" data-person-name="${statement.personName}" data-award-name="${statement.awardName}" data-award-url="${profileUrl(statement.uri("award"))}" data-date="${statement.dtv!}" data-award-org-name="${statement.orgname}" data-award-org-url="${profileUrl(statement.uri("orgid"))}">
 
 </#macro>


### PR DESCRIPTION
Supports the PR in the harvest code: https://github.com/cu-boulder/fis_harvestor_base/pull/26
Since the award org was broken out of the award name, made changes in this PR to show the awarding org name in the Organization display page.
Also set the Award name and awarding org name to URL links.
Examples of before and after can be seen at:
https://experts.colorado.edu/display/deptid_10220
and
https://vivo-cub-dev.colorado.edu/display/deptid_10220

Note that the org name was broken out of the award name in order to support cleaner data in Elastic for the courses taught Experts profile project.