### PR TITLE
facetview test to set index based on website url

### DIFF
--- a/webapp/src/main/webapp/themes/cu-boulder/templates/people.ftl
+++ b/webapp/src/main/webapp/themes/cu-boulder/templates/people.ftl
@@ -170,8 +170,16 @@
 
     <script type="text/javascript">
         jQuery(document).ready(function($) {
+	    if (document.location.hostname.search("setup") !== -1) {  
+                v_search_url = '/es/fis-setup-people/person/_search';
+	    } 
+	    else 
+	    { 
+	      v_search_url = '/es/fis/person/_search';
+	    }
+
             $('.facet-view-simple').facetview({
-                search_url: '/es/fis/person/_search',
+                search_url: v_search_url,
                 page_size: 10,
                 sort: [
                     {"_score" : {"order" : "desc"}},


### PR DESCRIPTION
Introduces a test in javascript to set the facetview elastic index to fis-setup-people if the website url includes the term "setup".
This allows the code for vivo-cub-setup-dev and vivo-cub-setup to automatically point to a different setup index. 
vivo-cub-setup-dev has a much smaller test case of people and publications which come from faculty_test. Until now the code needed to be manually modified to point to a setup index to show the smaller subset of people.

Code is deployed to vivo-cub-dev, vivo-cub-setup-dev, and vivo-cub-setup