### PR TITLE
verification code for google search console

### DIFF
--- a/webapp/src/main/webapp/themes/cu-boulder/templates/head.ftl
+++ b/webapp/src/main/webapp/themes/cu-boulder/templates/head.ftl
@@ -29,6 +29,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <meta charset="utf-8" />
 <!-- Google Chrome Frame open source plug-in brings Google Chrome's open web technologies and speedy JavaScript engine to Internet Explorer-->
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<!-- Google Analtyics Search Console Tab -->
+<meta name="google-site-verification" content="9WGiEnj8-kkG0SbYKkp39hMTj1WJeQ-Npuz0xhMeQ4o" />
 
 <title>${title} | CU Experts | CU Boulder</title>
 


### PR DESCRIPTION
Google needs this in the head in order to track data from Google Search
Data can be seen in the Google Search console:
https://search.google.com/

added search console for Experts to Google Analytics.
This is seen under Aquisition->Search Console

I already set this up on production since that's the only system that reports to GA.
This merge is a formality of updating the repo.