### PR TITLE
Facetedsearch - use setup index when on setup website

### DIFF
--- a/webapp/src/main/webapp/themes/cu-boulder/templates/publications.ftl
+++ b/webapp/src/main/webapp/themes/cu-boulder/templates/publications.ftl
@@ -23,8 +23,15 @@
 
     <script type="text/javascript">
         jQuery(document).ready(function($) {
+	    if (document.location.hostname.search("setup") !== -1) {  
+                v_search_url = '/es/fis-setup-pubs/publication/_search';
+	    } 
+	    else 
+	    { 
+	      v_search_url = '/es/fis/fispubs-v1/_search';
+	    }
             $('.facet-view-simple').facetview({
-                search_url: '/es/fispubs-v1/publication/_search',
+                search_url: v_search_url,
                 page_size: 20,
                 sort: [{"publicationYear.keyword" : {"order" : "desc"}}],
                 sharesave_link: true,


### PR DESCRIPTION
This change affects the facetedsearch Publications page.
This changes checks the URL of the VIVO page and uses a setup index if the URL name includes the word setup.
Allows the system to use multiple elasticsearch indexes, one for setup ( which in this case is a subset of data ) and one for the main site.
The people page already does this.
Ticket: webapp/src/main/webapp/themes/cu-boulder/templates/publications.ftl
