### PR TITLE
Engfis 726

### DIFF
--- a/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
@@ -84,4 +84,54 @@ pubs:cuscholar
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:publicDescriptionAnnot
               "Link to CU Scholar Open Access site"^^xsd:string .
+	      
+pubs:authorCount
+      a       owl:DatatypeProperty ;
+      rdfs:label "author count"@en-US ;
+      rdfs:range xsd:string ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "author count"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
+
+pubs:citationCount
+      a       owl:DatatypeProperty ;
+      rdfs:label "citation count"@en-US ;
+      rdfs:range xsd:string ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "citation count"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
+
+pubs:dataSource
+      a       owl:DatatypeProperty ;
+      rdfs:label "data source"@en-US ;
+      rdfs:range xsd:string ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "data source from Elements"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
+
+pubs:dateInCube
+      a       owl:DatatypeProperty ;
+      rdfs:label "Date in Cube"@en-US ;
+      rdfs:range xsd:dateTime ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "Date publication appeared in Elements"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
+
+pubs:fundingAcknowledgement
+      a       owl:DatatypeProperty ;
+      rdfs:label "Funding Acknowledgement"@en-US ;
+      rdfs:range xsd:string ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "Funding acknowledgement - restricted for campus so this is hidden from public"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
 

--- a/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
+++ b/home/src/main/resources/rdf/tbox/filegraph/fis_pubs.n3
@@ -117,12 +117,12 @@ pubs:dataSource
 
 pubs:dateInCube
       a       owl:DatatypeProperty ;
-      rdfs:label "Date in Cube"@en-US ;
+      rdfs:label "Date in CU Experts"@en-US ;
       rdfs:range xsd:dateTime ;
       vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
-      vitro:publicDescriptionAnnot "Date publication appeared in Elements"^^xsd:string ;
+      vitro:publicDescriptionAnnot "Date publication appeared in Elements/CU Experts"^^xsd:string ;
       vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
 
 pubs:fundingAcknowledgement
@@ -135,3 +135,12 @@ pubs:fundingAcknowledgement
       vitro:publicDescriptionAnnot "Funding acknowledgement - restricted for campus so this is hidden from public"^^xsd:string ;
       vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .
 
+pubs:citedEditors
+      a       owl:DatatypeProperty ;
+      rdfs:label "Full Editor List"@en-US ;
+      rdfs:range xsd:string ;
+      vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
+      vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupoverview> ;
+      vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
+      vitro:publicDescriptionAnnot "Full Editor List"^^xsd:string ;
+      vitro:displayRankAnnot "40"^^<http://www.w3.org/2001/XMLSchema#int> .


### PR DESCRIPTION
New fields for CIRES.

This modifies our CU Experts semanitic knowledge graph custom CU schema.

Note that 2 of the fields are not visible to the public. They have this attribute:
vitro:hiddenFromDisplayBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#editor> ;
Which means you need to be logged into Experts with "editor" role to see them.
This fulfills the requires of fundingAcknowledgement and dataSource not being visible for the public.

This is tested and deployed on dev. There are no pre-requisites for this PR.
This only creates the "schema"
 This is a pre-requisite for a subsequent PR for fis_harvester_base which will populate the data.
 
Adding others to the PR for reviewers. Feel free to look at the "Files changed" tab and/or look at the Jira or just watch the workflow.
